### PR TITLE
fix: css modified & admin login revised

### DIFF
--- a/src/components/TweetModal.vue
+++ b/src/components/TweetModal.vue
@@ -34,7 +34,7 @@
         <textarea class="scrollbar" name="tweet"> </textarea>
       </slot>
       <slot name="alert">
-        <span class="text-length"></span>
+        <span class="text-reply-length"></span>
         <span class="text-empty modal-alert"></span>
         <span class="text-exceed modal-alert"></span>
       </slot>
@@ -143,6 +143,12 @@ textarea {
   &::placeholder {
     color: $font-small;
   }
+}
+.text-reply-length {
+  @extend %form-label;
+  position: absolute;
+  bottom: 8px;
+  left: 0;
 }
 .modal-alert {
   color: $modal-alert;

--- a/src/components/UserFollowCard.vue
+++ b/src/components/UserFollowCard.vue
@@ -54,6 +54,9 @@ export default {
           margin-right: 8px;        
         }
       }
+      .text {
+        word-break: break-all;
+      }
     }
   }
 </style>

--- a/src/components/UserTweetCard.vue
+++ b/src/components/UserTweetCard.vue
@@ -69,17 +69,18 @@ export default {};
         width: 14px;
         height: 14px;
       }
-      &.icon-wrapper:nth-child(2) {
+      .icon-wrapper:nth-child(2) {
         margin-left: 40px;
       }
       .icon-wrapper {
         display: flex;
         align-items: center;
-        width: 2rem;
+        width: 4rem;
         font-size: 14px;
         color: $font-small;
         font-weight: 600;
         .count {
+          width: 2rem;
           margin-left: 9px;
         }
       }

--- a/src/router/index.js
+++ b/src/router/index.js
@@ -103,17 +103,20 @@ const routes = [
   // 後台
   {
     path: '/admin',
-    name: 'admin',  
+    name: 'admin', 
+    meta: { requiresAuth: true }, 
     component: () => import('../views/AdminSignin.vue')
   },
   {
     path: '/admin/tweets',
-    name: 'admin-tweets',    
+    name: 'admin-tweets',
+    meta: { requiresAuth: true },   
     component: () => import('../views/AdminTweetsList.vue')
   },
   {
     path: '/admin/users',
-    name: 'admin-users',   
+    name: 'admin-users',  
+    meta: { requiresAuth: true }, 
     component: () => import('../views/AdminUsers.vue')
   },
   // NotFound

--- a/src/views/AdminUsers.vue
+++ b/src/views/AdminUsers.vue
@@ -176,17 +176,25 @@ export default {
   flex-flow: column nowrap;
   justify-content: center;
   align-items: center;
+  
   &-name {
+    @extend %single-ellipsis;
+    width: 100%;
     color: $font-black;
     font-size: 16px;
     font-weight: 700;
     line-height: 26px;
+    text-align: center;
+    padding: 0 16px;
   }
   &-account {
+    @extend %single-ellipsis;
     color: $font-small;
     font-size: 14px;
     font-weight: 400;
     line-height: 22px;
+    text-align: center;
+    padding: 0 16px;
   }
   &-tweets-likes, &-follow {
     display: flex;

--- a/src/views/Twitter.vue
+++ b/src/views/Twitter.vue
@@ -121,11 +121,11 @@
               </textarea>
             </template>
             <template v-slot:alert>
-              <!-- <span class="text-length">{{ isReplyModel ? textReply.length : text.length }}/140</span> -->
-              <span v-if="!isModalEmpty" class="text-empty modal-alert warning"
+              <span class="text-reply-length">{{ textReply.length }}/140</span>
+              <span v-if="!isModalEmpty" class="modal-alert warning"
                 >內容不可空白</span
               >
-              <span v-if="isModalExceed" class="text-exceed modal-alert warning"
+              <span v-if="isModalExceed" class="modal-alert warning"
                 >字數不可超過 140 字</span
               >
             </template>
@@ -332,7 +332,7 @@ export default {
     // 按讚
     async likeTweet(id) {
       try {
-        this.isProcessing = true;
+        // this.isProcessing = true;
         const { data } = await tweetAPI.likeTweet({ id });
 
         if (data.status !== "success") {
@@ -352,9 +352,9 @@ export default {
             };
           }
         });
-        this.isProcessing = false;
+        // this.isProcessing = false;
       } catch (error) {
-        this.isProcessing = false;
+        // this.isProcessing = false;
         console.log(error);
         Toast.fire({
           icon: "error",
@@ -569,15 +569,25 @@ export default {
     border-radius: 50%;
   }
 }
+// .text-reply-length {
+
+//   position: absolute;
+//   right: 1rem;
+//   bottom: 1rem;
+//   // margin-bottom: 0;
+// }
 .modal-tweet {
   @extend %button-orange;
   min-width: 76px;
   height: 40px;
-  &.button-reply {
-    position: absolute;
-    right: 1rem;
-    bottom: 1rem;
-  }
+  position: absolute;
+  right: 1rem;
+  bottom: 1rem;
+  // &.button-reply {
+  //   position: absolute;
+  //   right: 1rem;
+  //   bottom: 1rem;
+  // }
   &:disabled {
     background: $form-input-placeholder;
   }

--- a/src/views/TwitterReply.vue
+++ b/src/views/TwitterReply.vue
@@ -88,7 +88,7 @@
             <div class="icon-wrapper">
               <img src="../assets/static/images/reply@2x.png" alt="" />
               <!-- TODO:暫填，非真實數據 -->
-              <p class="count">{{ reply.User.id }}</p>
+              <p class="count">0</p>
             </div>
             <div class="icon-wrapper">
               <img src="../assets/static/images/like@2x.png" alt="" />
@@ -99,7 +99,7 @@
                 @click.stop.prevent="unlikeTweet(tweet.id)"
               /> -->
               <!-- TODO:暫填，非真實數據 -->
-              <p class="count">{{ reply.User.id }}</p>
+              <p class="count">0</p>
             </div>
           </div>
         </template>


### PR DESCRIPTION
1. 回覆推文 icon 的回覆和按讚功能尚未開發，改成放假數字０
2. 破版樣式調整：userFolloweCard、adminUserCard、userTweetCard
3. 未登入造訪 admin 推文列表和 user 列表設為需驗證的頁面