### PR TITLE
Fix/bug

### DIFF
--- a/src/components/Sidebar.vue
+++ b/src/components/Sidebar.vue
@@ -250,20 +250,6 @@ export default {
           UserId: this.currentUser.id,
         });
 
-        const { id, description, UserId, createdAt } = data.data
-
-        this.newTweet = {
-          id, // 推文 id
-          description,
-          createdAt,
-          User: { id: UserId },
-        };
-
-        this.tweets = [
-          { ...this.newTweet }, 
-          ...this.tweets
-        ];
-
         if (data.status !== "success") {
           throw new Error(data.message);
         } else {
@@ -288,11 +274,11 @@ export default {
         }
       }
     },
-    updateTweet() {
-      this.createTweet()
-      this.fetchTweets()
+    async updateTweet() {
+      //使用sync await確保createTweet動作完成後，再emit給TwitterMain處理update的動作
+      const update = await this.createTweet()
       // 點擊 Modal 中的推文按鈕後，emit 到 TwitterMain
-      this.$emit('update')
+      this.$emit('update', update)
     },
     // 開啟 Modal
     tweetModal() {

--- a/src/components/SignInForm.vue
+++ b/src/components/SignInForm.vue
@@ -51,7 +51,6 @@ export default {
     async handleSubmit(){
       try{
         this.isProcessing = true
-        this.$store.commit("setIsLoading", true);
         if ( !this.account || !this.password ) {
           this.isProcessing = false
           Toast.fire({
@@ -67,6 +66,7 @@ export default {
         if ( data.status !== 'success' ) {
           throw new Error(data.message)
         }
+        this.$store.commit("setIsLoading", true);
         const {user} = data.data
         const isAdmin = user.is_admin
         const route = this.$route.name
@@ -88,10 +88,11 @@ export default {
         this.$router.push('/twitter')
         return
       } else {
+        this.$store.commit("setIsLoading", false);
         this.isProcessing= false,
         this.isValid = false
         }
-         this.password = ''
+        this.password = ''
         this.isProcessing = false
       }catch(error){
         this.isProcessing = false

--- a/src/views/AdminTweetsList.vue
+++ b/src/views/AdminTweetsList.vue
@@ -104,10 +104,8 @@ export default {
         showCancelButton: true
       }).then( result => {
           if(result.value){
-            console.log('刪除',result.value)
             return this.deleteTweet(id)
           }else if(result.dismiss === 'cancel'){
-            console.log('取消',result)
             return        
           }
         }

--- a/src/views/Setting.vue
+++ b/src/views/Setting.vue
@@ -168,7 +168,6 @@ export default {
   watch: {
     user() {
       this.textWarning()
-      console.log(this.user.account)
     }
   },
   created() {

--- a/src/views/User.vue
+++ b/src/views/User.vue
@@ -116,7 +116,6 @@
       async fetchUser(userId){
         try{
           this.$store.commit("setIsLoading", true);
-          // TODO:篩除非user的用戶
           const {data, statusText} = await userAPI.get({id:userId})   
           const {id,role, name, account ,coverImg, avatarImg, introduction, is_following:isFollowing, Following: following, Follower: follower} = data
 
@@ -157,6 +156,8 @@
         } catch(error){
           if(error.response.status === 500){
             this.tweetNum = 0
+            //無推文時會報錯500，所以當無推文時需要給空陣列否則tweets的資料不會被更新
+            this.tweets = []
             return
           }       
         }
@@ -197,7 +198,7 @@
     computed:{
       ...mapState(['currentUser'])
     },
-     beforeRouteUpdate(to, from, next){
+    beforeRouteUpdate(to, from, next){
       const {id} = to.params
       this.newRoute = id
       this.fetchUser(id)

--- a/src/views/UserFollower.vue
+++ b/src/views/UserFollower.vue
@@ -184,6 +184,11 @@ export default {
     // 當 initialFollowers 有更新，就重新賦值給 followers
     initialFollowers(newVal) {
       this.followers = [...newVal]
+      if (this.followers.length === 0) {
+        this.noFollowers = true
+      } else {
+        this.noFollowers = false
+      }
     }
   }
 }

--- a/src/views/UserFollowing.vue
+++ b/src/views/UserFollowing.vue
@@ -188,6 +188,11 @@ export default {
     // 當 initialFollowings 有更新，就重新賦值給 followings
     initialFollowings(newVal) {
       this.followings = [...newVal]
+      if (this.followings.length === 0) {
+        this.noFollowings = true
+      } else {
+        this.noFollowings = false
+      }      
     }
   }
 }

--- a/src/views/UserTweets.vue
+++ b/src/views/UserTweets.vue
@@ -160,6 +160,11 @@ export default {
   watch: {
     initialTweets(newVal) {
       this.tweets = [...newVal]
+      if (this.tweets.length === 0) {
+        this.noTweets = true
+      } else {
+        this.noTweets = false
+      }   
     }
   }
 };


### PR DESCRIPTION
1. 修復登入時因過早切換loading狀態導致登入帳號密碼有誤時，會出現spinner跳出空轉的bug。 修改為sign in確定成功後才切換loading狀態。
2. 修復 sidebar 中推文功能因同步非同步問題造成的bug。
3. 修復在切換不同user的個人頁時，沒有發布過推文的用戶的會拿到上一位用戶的資料的問題。因為當用戶尚未發佈任何推文時，伺服器會回傳error 500，因此錯誤處理時需要針對這部分進行處理回傳空陣列。
4. 修復userFollowers、userFollowings、userTweets在資料更新時，判斷是否有資料的狀態(noFollow / noTweets)沒有切換，造成雖有資料但還是會出現尚未有資料提示的問題。透過watch 當資料有更新重新賦值時也一併根據資料的有無切換狀態隱藏或顯示尚未有資料的提示。
5.移除sidbar中推文功能多餘的程式碼(sidebar中不需要全部推文的資料，只需要createTweet和emit給父元件進行update的動作)
6.移除testing用的console